### PR TITLE
deploy: enable CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,8 +38,8 @@ jobs:
     # Only run this job if the "ci" job passes
     needs: ci
 
-    # Only run this job if new work is pushed to "main"
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Only run this job if new work is pushed to "master"
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
 
     # Set up operating system
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR proposes enabling the CD workflow by fixing the expected branch name from `cookiecutter` template.